### PR TITLE
Manage jmxtrans /var/run/ directory

### DIFF
--- a/templates/jmxtrans.service.epp
+++ b/templates/jmxtrans.service.epp
@@ -9,6 +9,7 @@ User=<%= $user %>
 PermissionsStartOnly=true
 ExecStartPre=-/usr/bin/mkdir -p /var/run/jmxtrans/
 ExecStartPre=/usr/bin/chown -R <%= $user %> /run/jmxtrans/
+RuntimeDirectory=jmxtrans  
 PIDFile=/var/run/jmxtrans/jmxtrans.pid
 ExecStart=/usr/share/jmxtrans/bin/jmxtrans start
 


### PR DESCRIPTION
As mentioned in
https://freedesktop.org/software/systemd/man/systemd.exec.html,
RuntimeDirectory creates subdirs in /var/run with the correct
permissions.  Currently, upon a reboot of a server, jmxtrans will fail
to start as it can't write its pid file because /var/run/jmxtrans
doesn't exist