### PR TITLE
Systemd template parametrized

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "rake"
+  gem "rake", '< 12.0.0'
   gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 4.1.0'
   gem "rspec", '< 3.2.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,12 @@ class jmxtrans::config {
           owner   => 'root',
           group   => 'root',
           mode    => '0444',
-          content => epp($::jmxtrans::systemd_template, { 'user' => $::jmxtrans::user }),
+          content => epp($::jmxtrans::systemd_template, {
+            'user'                     => $::jmxtrans::user,
+            'binary_path'              => $::jmxtrans::binary_path,
+            'working_directory'        => $::jmxtrans::working_directory,
+            'systemd_environment_file' => $::jmxtrans::systemd_environment_file,
+          }),
         }
         ~>
         exec { 'jmxtrans systemctl daemon-reload':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,7 @@ class jmxtrans::config {
           owner   => 'root',
           group   => 'root',
           mode    => '0444',
-          content => epp('jmxtrans/jmxtrans.service.epp', { 'user' => $::jmxtrans::user }),
+          content => epp($::jmxtrans::systemd_template, { 'user' => $::jmxtrans::user }),
         }
         ~>
         exec { 'jmxtrans systemctl daemon-reload':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class jmxtrans (
   Optional[String[1]] $service_name = undef,
   Optional[String[1]] $package_source = undef,
   Optional[String[1]] $package_provider = undef,
+  Optional[String[1]] $working_directory = undef,
   Boolean $manage_service_file = false,
   Optional[Array[String]] $systemd_environment_vars = [],
   String[1] $systemd_template = 'jmxtrans/jmxtrans.service.epp',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@
 #
 class jmxtrans (
   Optional[String[1]] $package_name = undef,
+  Optional[String[1]] $package_version = undef,
   Optional[String[1]] $service_name = undef,
   Optional[String[1]] $package_source = undef,
   Optional[String[1]] $package_provider = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,9 @@ class jmxtrans (
   Optional[String[1]] $package_source = undef,
   Optional[String[1]] $package_provider = undef,
   Boolean $manage_service_file = false,
+  Optional[Array[String]] $systemd_environment_vars = [],
+  String[1] $systemd_template = 'jmxtrans/jmxtrans.service.epp',
+  String[1] $binary_path = '/usr/share/jmxtrans/bin/jmxtrans.sh',
   String[1] $config_directory = '/var/lib/jmxtrans',
   String[1] $user = 'jmxtrans',
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,21 +31,32 @@
 #
 # @param package_provider [String] (optional) Used to explicitly set the provider to use to install the package.
 #
+# @param working_directory [String] (optional) Sets the working directory for the jmxtrans processes.
+#
+# @param systemd_environment_file [String] (optional) Path to the file where the environment variables needed by
+# the jmxtrans service should be defined (e.g. '/etc/default/jmxtrans' or '/etc/sysconfig/jmxtrans').
+#
+# @param package_version [String] The version of the package to be installed. Defaults to 'present'.
+#
+# @param systemd_template [String] Template to be be used to generate the systemd unit. Defaults to 'jmxtrans/jmxtrans.service.pp'
+#
+# @param binary_path [String] Path to the jmxtrans executable. Defaults to '/usr/share/jmxtrans/bin/jmxtrans'.
+#
 # @param config_directory [String] Where to place JSON configurations. Defaults to '/var/lib/jmxtrans'.
 #
 # @param user [String] The user who will own the JSON configurations. Defaults to 'jmxtrans'.
 #
 class jmxtrans (
   Optional[String[1]] $package_name = undef,
-  Optional[String[1]] $package_version = undef,
   Optional[String[1]] $service_name = undef,
   Optional[String[1]] $package_source = undef,
   Optional[String[1]] $package_provider = undef,
   Optional[String[1]] $working_directory = undef,
+  Optional[String[1]] $systemd_environment_file = undef,
   Boolean $manage_service_file = false,
-  Optional[Array[String]] $systemd_environment_vars = [],
+  String[1] $package_version = present,
   String[1] $systemd_template = 'jmxtrans/jmxtrans.service.epp',
-  String[1] $binary_path = '/usr/share/jmxtrans/bin/jmxtrans.sh',
+  String[1] $binary_path = '/usr/share/jmxtrans/bin/jmxtrans',
   String[1] $config_directory = '/var/lib/jmxtrans',
   String[1] $user = 'jmxtrans',
 ) {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,8 +26,14 @@ class jmxtrans::install {
     } else {
       $provider = undef
     }
+
+    $manage_package = $::jmxtrans::package_version ? {
+      ''      => present,
+      default => $jmxtrans::package_version,
+    }
+
     package { $::jmxtrans::package_name:
-      ensure   => present,
+      ensure   => $manage_package,
       provider => $provider,
       source   => $::jmxtrans::package_source,
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,13 +27,8 @@ class jmxtrans::install {
       $provider = undef
     }
 
-    $manage_package = $::jmxtrans::package_version ? {
-      ''      => present,
-      default => $jmxtrans::package_version,
-    }
-
     package { $::jmxtrans::package_name:
-      ensure   => $manage_package,
+      ensure   => $::jmxtrans::package_version,
       provider => $provider,
       source   => $::jmxtrans::package_source,
     }

--- a/spec/classes/jmxtrans_spec.rb
+++ b/spec/classes/jmxtrans_spec.rb
@@ -131,6 +131,83 @@ describe 'jmxtrans' do
           end
         end
 
+        context 'jmxtrans class with systemd and service unit' do
+          context 'no changes' do
+            let(:facts) {
+              {
+                :path             => '/usr/local/sbin',
+                :service_provider => 'systemd',
+              }
+            }
+            let(:params) {{
+              :manage_service_file => true,
+            }}
+
+            it { is_expected.to compile.with_all_deps }
+
+            it { is_expected.to contain_file('/etc/systemd/system/jmxtrans.service') }
+            it { is_expected.to contain_file('/etc/systemd/system/jmxtrans.service').with_content(/ExecStart=\/usr\/share\/jmxtrans\/bin\/jmxtrans/) }
+            it { is_expected.to_not contain_file('/etc/systemd/system/jmxtrans.service').with_content(/EnvironmentFile=\/etc\/default\/jmxtrans/) }
+            it { is_expected.to_not contain_file('/etc/systemd/system/jmxtrans.service').with_content(/WorkingDirectory=\/usr\/share\/jmxtrans/) }
+          end
+
+          context 'set environment file' do
+            let(:facts) {
+              {
+                :path             => '/usr/local/sbin',
+                :service_provider => 'systemd',
+              }
+            }
+            let(:params) {{
+              :manage_service_file => true,
+              :systemd_environment_file => '/etc/default/jmxtrans',
+            }}
+
+            it { is_expected.to compile.with_all_deps }
+
+            it { is_expected.to contain_file('/etc/systemd/system/jmxtrans.service') }
+            it { is_expected.to contain_file('/etc/systemd/system/jmxtrans.service').with_content(/EnvironmentFile=\/etc\/default\/jmxtrans/) }
+          end
+
+          context 'set working directory' do
+            let(:facts) {
+              {
+                :path             => '/usr/local/sbin',
+                :service_provider => 'systemd',
+              }
+            }
+
+            let(:params) {{
+              :manage_service_file => true,
+              :working_directory => '/usr/share/jmxtrans',
+            }}
+
+            it { is_expected.to compile.with_all_deps }
+
+            it { is_expected.to contain_file('/etc/systemd/system/jmxtrans.service') }
+            it { is_expected.to contain_file('/etc/systemd/system/jmxtrans.service').with_content(/WorkingDirectory=\/usr\/share\/jmxtrans/) }
+          end
+
+          context 'set working directory' do
+            let(:facts) {
+              {
+                :path             => '/usr/local/sbin',
+                :service_provider => 'systemd',
+              }
+            }
+
+            let(:params) {{
+              :manage_service_file => true,
+              :binary_path => '/usr/share/jmxtrans/bin/jmxtrans.sh',
+            }}
+
+            it { is_expected.to compile.with_all_deps }
+
+            it { is_expected.to contain_file('/etc/systemd/system/jmxtrans.service') }
+            it { is_expected.to contain_file('/etc/systemd/system/jmxtrans.service').with_content(/ExecStart=\/usr\/share\/jmxtrans\/bin\/jmxtrans.sh/) }
+          end
+        end
+
         context 'jmxtrans class with package provider' do
           let(:params) {{
             :package_name => 'jmxtrans',
@@ -184,6 +261,26 @@ describe 'jmxtrans' do
             end
             it { is_expected.to contain_service('jmxtrans') }
           end
+        end
+
+        context 'jmxtrans class with package version' do
+          let(:params) {{
+            :package_name => 'jmxtrans',
+            :service_name => 'jmxtrans',
+            :package_version => '265'
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_class('jmxtrans::install') }
+          it { is_expected.to contain_class('jmxtrans::service').that_subscribes_to('jmxtrans::install') }
+
+          it do
+            is_expected.to contain_package('jmxtrans').with({
+              'ensure' => '265',
+            })
+          end
+          it { is_expected.to contain_service('jmxtrans') }
         end
       end
     end

--- a/templates/jmxtrans.service.epp
+++ b/templates/jmxtrans.service.epp
@@ -10,7 +10,9 @@ User=<%= $user %>
 Environment=<%= $var %>
 <% } -%>
 <% } -%>
-WorkingDirectory=/usr/share/jmxtrans
+<% if $jmxtrans::working_directory { -%>
+WorkingDirectory=<%= $jmxtrans::working_directory %>
+<% } -%>
 PermissionsStartOnly=true
 RuntimeDirectory=jmxtrans  
 PIDFile=/var/run/jmxtrans/jmxtrans.pid

--- a/templates/jmxtrans.service.epp
+++ b/templates/jmxtrans.service.epp
@@ -5,10 +5,16 @@ After=syslog.target network.target
 [Service]
 Type=forking
 User=<%= $user %>
+<% if $jmxtrans::systemd_environment_vars =~ Array[String] { -%>
+<% $jmxtrans::systemd_environment_vars.flatten.each |$var| { -%>
+Environment=<%= $var %>
+<% } -%>
+<% } -%>
+WorkingDirectory=/usr/share/jmxtrans
 PermissionsStartOnly=true
 RuntimeDirectory=jmxtrans  
 PIDFile=/var/run/jmxtrans/jmxtrans.pid
-ExecStart=/usr/share/jmxtrans/bin/jmxtrans start
+ExecStart=<%= $jmxtrans::binary_path %> start
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/jmxtrans.service.epp
+++ b/templates/jmxtrans.service.epp
@@ -5,18 +5,16 @@ After=syslog.target network.target
 [Service]
 Type=forking
 User=<%= $user %>
-<% if $jmxtrans::systemd_environment_vars =~ Array[String] { -%>
-<% $jmxtrans::systemd_environment_vars.flatten.each |$var| { -%>
-Environment=<%= $var %>
+<% if $systemd_environment_file  { -%>
+EnvironmentFile=<%= $systemd_environment_file %>
 <% } -%>
-<% } -%>
-<% if $jmxtrans::working_directory { -%>
-WorkingDirectory=<%= $jmxtrans::working_directory %>
+<% if $working_directory { -%>
+WorkingDirectory=<%= $working_directory %>
 <% } -%>
 PermissionsStartOnly=true
 RuntimeDirectory=jmxtrans  
 PIDFile=/var/run/jmxtrans/jmxtrans.pid
-ExecStart=<%= $jmxtrans::binary_path %> start
+ExecStart=<%= $binary_path %> start
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently, just the user setting can be modified in the systemd template.
In this PR, different parameters have been added in order to customize the systemd template by means of:
 - adding environment variables
 - setting a working directory
 - setting a different path for the jmxtran sexecutable

Furthermore, a new parameter has been added in order to set the jmxtrans version.

As example, hiera in settings would be like:
```jmxtrans::package_name: jmxtrans
jmxtrans::package_version: '265'
jmxtrans::service_name: jmxtrans
jmxtrans::manage_service_file: true
jmxtrans::working_directory: '/usr/share/jmxtrans'
jmxtrans::systemd_environment_vars:
  - LOG_DIR=/var/log/jmxtrans
  - SECONDS_BETWEEN_RUNS=60
  - JSON_DIR=/var/lib/jmxtrans
  - HEAP_SIZE=512
  - NEW_SIZE=64
  - CPU_CORES=2
  - NEW_RATIO=8
  - LOG_LEVEL=debug
  - PIDFILE=/var/run/jmxtrans/jmxtrans.pid
```