### PR TITLE
allow a URL source to be passed to dpkg

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,24 +28,24 @@ class jmxtrans::install {
     }
 
     # dpkg does'nt support installing from a URL, so this downloads a source file from a URL if one is provided.
-    if $provider == 'dpkg' and $::jmxtrans::package_source.match(/^http.*/) {
+    if $provider == 'dpkg' and $jmxtrans::package_source.match(/^http.*/) {
 
       archive { '/tmp/jmxtrans.deb':
-        source => $::jmxtrans::package_source,
+        source => $jmxtrans::package_source,
       }
 
-      package { $::jmxtrans::package_name:
-        ensure   => $::jmxtrans::package_version,
+      package { $jmxtrans::package_name:
+        ensure   => $jmxtrans::package_version,
         provider => $provider,
         source   => '/tmp/jmxtrans.deb',
         require  => Archive['/tmp/jmxtrans.deb'],
       }
     } else {
 
-      package { $::jmxtrans::package_name:
-        ensure   => $::jmxtrans::package_version,
+      package { $jmxtrans::package_name:
+        ensure   => $jmxtrans::package_version,
         provider => $provider,
-        source   => $::jmxtrans::package_source,
+        source   => $jmxtrans::package_source,
       }
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,10 +27,26 @@ class jmxtrans::install {
       $provider = undef
     }
 
-    package { $::jmxtrans::package_name:
-      ensure   => $::jmxtrans::package_version,
-      provider => $provider,
-      source   => $::jmxtrans::package_source,
+    # dpkg does'nt support installing from a URL, so this downloads a source file from a URL if one is provided.
+    if $provider == 'dpkg' and $::jmxtrans::package_source.match(/^http.*/) {
+
+      archive { '/tmp/jmxtrans.deb':
+        source => $::jmxtrans::package_source,
+      }
+
+      package { $::jmxtrans::package_name:
+        ensure   => $::jmxtrans::package_version,
+        provider => $provider,
+        source   => '/tmp/jmxtrans.deb',
+        require  => Archive['/tmp/jmxtrans.deb'],
+      }
+    } else {
+
+      package { $::jmxtrans::package_name:
+        ensure   => $::jmxtrans::package_version,
+        provider => $provider,
+        source   => $::jmxtrans::package_source,
+      }
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.10.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
+    },
+    {
+      "name": "puppet/archive",
+      "version_requirement": ">= 1.0.1 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The dpkg provider doesn't support an http(s) source.  This commit uses the archive module to expand the provider's functionality

> If you have a package available on the local filesystem or remotely over HTTP (if your package manager supports it), you can set the package_source parameter.